### PR TITLE
:sparkles: retrieve path methods support month

### DIFF
--- a/bdc_collectors/base.py
+++ b/bdc_collectors/base.py
@@ -106,7 +106,7 @@ class BaseCollection:
         """
         return dict()
 
-    def path(self, collection, prefix=None) -> Path:
+    def path(self, collection, prefix=None, path_include_month=False) -> Path:
         """Retrieve the relative path to the Collection on Brazil Data Cube cluster.
 
         Note:
@@ -129,7 +129,7 @@ class BaseCollection:
 
         return scene_path
 
-    def compressed_file(self, collection, prefix=None) -> Path:
+    def compressed_file(self, collection, prefix=None, path_include_month=False) -> Path:
         """Retrieve the path to the compressed file L1.
 
         .. deprecated:: 0.6.2

--- a/bdc_collectors/scihub/base.py
+++ b/bdc_collectors/scihub/base.py
@@ -78,7 +78,7 @@ class SentinelCollection(BaseCollection):
 
         return output
 
-    def compressed_file(self, collection, prefix=None):
+    def compressed_file(self, collection, prefix=None, path_include_month=False):
         """Retrieve path to the compressed scene (.zip) on local storage."""
         if prefix is None:
             prefix = current_app.config.get('DATA_DIR')
@@ -90,11 +90,16 @@ class SentinelCollection(BaseCollection):
 
         relative = Path(collection.name) / version / tile[:2] / tile[2] / tile[3:] / year / scene_id
 
+        if path_include_month:
+            month = str(self.parser.sensing_date().month)
+            relative = Path(collection.name) / version / \
+                tile[:2] / tile[2] / tile[3:] / year / month / scene_id
+
         scene_path = Path(prefix or '') / relative
 
         return scene_path / f'{scene_id}.zip'
 
-    def path(self, collection, prefix=None) -> Path:
+    def path(self, collection, prefix=None, path_include_month=False) -> Path:
         """Retrieve the relative path to the Collection on Brazil Data Cube cluster."""
         if prefix is None:
             prefix = current_app.config.get('DATA_DIR')
@@ -104,6 +109,11 @@ class SentinelCollection(BaseCollection):
         year = str(self.parser.sensing_date().year)
 
         relative = Path(collection.name) / version / tile[:2] / tile[2] / tile[3:] / year / self.parser.scene_id
+
+        if path_include_month:
+            month = str(self.parser.sensing_date().month)
+            relative = Path(collection.name) / version / \
+                tile[:2] / tile[2] / tile[3:] / year / month / self.parser.scene_id
 
         scene_path = Path(prefix or '') / relative
 


### PR DESCRIPTION
Permite que os métodos .compressed_file() e .path() das classes BaseCollection e SentinelCollection possam incluir o mês na composição do _path_ recuperado.